### PR TITLE
fix: keep the initial slash for fetching VERSION.txt

### DIFF
--- a/addon/services/new-version.js
+++ b/addon/services/new-version.js
@@ -82,11 +82,6 @@ export default class NewVersionService extends Service {
     const versionFileName = this._newVersionConfig.versionFileName;
     const baseUrl =
       this._config.prepend || this._config.rootURL || this._config.baseURL;
-
-    if (!this._config || baseUrl === '/') {
-      return versionFileName;
-    }
-
     return baseUrl + versionFileName;
   }
 


### PR DESCRIPTION
Before this commit, the fetch of VERSION.txt with a default configuration would result to calling "VERSION.txt", which means "fetch the file relative to the current page URL".

This may lead to issue in production, but leads to issues in some tests situation when using `ember test` where the full path to VERSION.txt is resolved to `/VERSION.txt` when declaring it in tests, while it is resolved to `http://localhost:7357/some-random-numbers/tests/VERSION.txt` when fetching the file.

This commit fixes the issue by not removing the `/` in front of VERSION.txt.

This fixes the isse for my scenarios; but I am not sure why there was this check and removal of the `/` in the first place, this thus may lead to breaking changes for some.